### PR TITLE
Enhancement/confirm delete modal

### DIFF
--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -125,12 +125,12 @@
                   v-on:click="isDeleteModalOpen = !isDeleteModalOpen"
                   aria-label="close"
                 )
-              section.modal-card-body.modal-card-body-footer
+              section.modal-card-body
                 p Are you sure you want to delete the label <b>{{ deleteModalData.text }}</b>?
+              footer.modal-card-foot.pt20.pb20.pr20.pl20.has-background-white-ter
                 a.button.is-primary(v-on:click="removeLabel(deleteModalData)")
-                    span Yes, delete!
-                    span.icon.is-small
-                      i.fas.fa-trash
+                    span Delete
+                button.button(v-on:click="isDeleteModalOpen = !isDeleteModalOpen") Cancel
 
           div.columns(v-show="label === editedLabel")
             div.column

--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -111,10 +111,26 @@
                       span Edit
 
                   p.control
-                    a.button.is-text(v-on:click="removeLabel(label)")
+                    a.button.is-text(v-on:click="confirmDeleteModal(label)")
                       span.icon.is-small
                         i.fas.fa-trash
                       span Delete
+
+          div.modal(v-if="isDeleteModalOpen" v-bind:class="{ 'is-active': isDeleteModalOpen }" :data="deleteModalData")
+            div.modal-background
+            div.modal-card
+              header.modal-card-head
+                p.modal-card-title Delete Label 
+                button.delete(
+                  v-on:click="isDeleteModalOpen = !isDeleteModalOpen"
+                  aria-label="close"
+                )
+              section.modal-card-body.modal-card-body-footer
+                p Are you sure you want to delete the label <b>{{ deleteModalData.text }}</b>?
+                a.button.is-primary(v-on:click="removeLabel(deleteModalData)")
+                    span Yes, delete!
+                    span.icon.is-small
+                      i.fas.fa-trash
 
           div.columns(v-show="label === editedLabel")
             div.column
@@ -205,6 +221,8 @@ export default {
     editedLabel: null,
     messages: [],
     shortKeys: 'abcdefghijklmnopqrstuvwxyz',
+    isDeleteModalOpen: false,
+    deleteModalData: null,
   }),
 
   created() {
@@ -268,8 +286,14 @@ export default {
         });
     },
 
+    confirmDeleteModal(label) {
+      this.deleteModalData = label;
+      this.isDeleteModalOpen = !this.isDeleteModalOpen;
+    },
+
     removeLabel(label) {
       const labelId = label.id;
+      this.isDeleteModalOpen = !this.isDeleteModalOpen;
       HTTP.delete(`labels/${labelId}`).then(() => {
         const index = this.labels.indexOf(label);
         this.labels.splice(index, 1);

--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -118,7 +118,7 @@
 
           div.modal(v-if="isDeleteModalOpen",
                     v-bind:class="{ 'is-active': isDeleteModalOpen }"
-                    :data="deleteModalData")
+                    v-bind:data="deleteModalData")
             div.modal-background
             div.modal-card
               header.modal-card-head

--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -116,11 +116,13 @@
                         i.fas.fa-trash
                       span Delete
 
-          div.modal(v-if="isDeleteModalOpen" v-bind:class="{ 'is-active': isDeleteModalOpen }" :data="deleteModalData")
+          div.modal(v-if="isDeleteModalOpen",
+                    v-bind:class="{ 'is-active': isDeleteModalOpen }"
+                    :data="deleteModalData")
             div.modal-background
             div.modal-card
               header.modal-card-head
-                p.modal-card-title Delete Label 
+                p.modal-card-title Delete Label
                 button.delete(
                   v-on:click="isDeleteModalOpen = !isDeleteModalOpen"
                   aria-label="close"

--- a/app/server/static/components/label.vue
+++ b/app/server/static/components/label.vue
@@ -116,9 +116,11 @@
                         i.fas.fa-trash
                       span Delete
 
-          div.modal(v-if="isDeleteModalOpen",
-                    v-bind:class="{ 'is-active': isDeleteModalOpen }"
-                    v-bind:data="deleteModalData")
+          div.modal(
+            v-if="isDeleteModalOpen"
+            v-bind:class="{ 'is-active': isDeleteModalOpen }"
+            v-bind:data="deleteModalData"
+          )
             div.modal-background
             div.modal-card
               header.modal-card-head
@@ -131,7 +133,7 @@
                 p Are you sure you want to delete the label <b>{{ deleteModalData.text }}</b>?
               footer.modal-card-foot.pt20.pb20.pr20.pl20.has-background-white-ter
                 a.button.is-primary(v-on:click="removeLabel(deleteModalData)")
-                    span Delete
+                  span Delete
                 button.button(v-on:click="isDeleteModalOpen = !isDeleteModalOpen") Cancel
 
           div.columns(v-show="label === editedLabel")

--- a/app/server/static/components/users.vue
+++ b/app/server/static/components/users.vue
@@ -61,10 +61,28 @@
               )
                 | {{ otherRole.name }}
           b-table-column(label="Action")
-            a.button.is-text(v-on:click="removeRoleMapping(props.row.id)")
+            a.button.is-text(v-on:click="confirmDeleteModal(props.row)")
               span.icon.is-small
                 i.fas.fa-trash
               span Delete
+
+    div.modal(v-if="isDeleteModalOpen",
+              v-bind:class="{ 'is-active': isDeleteModalOpen }"
+              :data="deleteModalData")
+      div.modal-background
+      div.modal-card
+        header.modal-card-head
+          p.modal-card-title Delete User
+          button.delete(
+            v-on:click="isDeleteModalOpen = !isDeleteModalOpen"
+            aria-label="close"
+          )
+        section.modal-card-body
+          p Are you sure you want to delete the user <b>{{ deleteModalData.username }}</b>?
+        footer.modal-card-foot.pt20.pb20.pr20.pl20.has-background-white-ter
+          a.button.is-primary(v-on:click="removeRoleMapping(deleteModalData.id)")
+              span Delete
+          button.button(v-on:click="isDeleteModalOpen = !isDeleteModalOpen") Cancel
 </template>
 
 <style>
@@ -99,6 +117,8 @@ export default {
     allUsers: [],
     otherUsers: [],
     roles: [],
+    isDeleteModalOpen: false,
+    deleteModalData: null,
   }),
 
   computed: {
@@ -158,7 +178,13 @@ export default {
       this.newRoleMapping = null;
     },
 
+    confirmDeleteModal(userData) {
+      this.deleteModalData = userData;
+      this.isDeleteModalOpen = !this.isDeleteModalOpen;
+    },
+
     removeRoleMapping(roleMappingId) {
+      this.isDeleteModalOpen = !this.isDeleteModalOpen;
       HTTP.delete(`roles/${roleMappingId}`).then(() => {
         this.roleMappings = this.roleMappings.filter(
           roleMapping => roleMapping.id !== roleMappingId,

--- a/app/server/static/components/users.vue
+++ b/app/server/static/components/users.vue
@@ -68,7 +68,7 @@
 
     div.modal(v-if="isDeleteModalOpen",
               v-bind:class="{ 'is-active': isDeleteModalOpen }"
-              :data="deleteModalData")
+              v-bind:data="deleteModalData")
       div.modal-background
       div.modal-card
         header.modal-card-head

--- a/app/server/static/components/users.vue
+++ b/app/server/static/components/users.vue
@@ -72,13 +72,13 @@
       div.modal-background
       div.modal-card
         header.modal-card-head
-          p.modal-card-title Delete User
+          p.modal-card-title Delete User Role
           button.delete(
             v-on:click="isDeleteModalOpen = !isDeleteModalOpen"
             aria-label="close"
           )
         section.modal-card-body
-          p Are you sure you want to delete the user <b>{{ deleteModalData.username }}</b>?
+          p Are you sure you want to delete the role for user <b>{{ deleteModalData.username }}</b>?
         footer.modal-card-foot.pt20.pb20.pr20.pl20.has-background-white-ter
           a.button.is-primary(v-on:click="removeRoleMapping(deleteModalData.id)")
               span Delete

--- a/app/server/static/components/users.vue
+++ b/app/server/static/components/users.vue
@@ -66,9 +66,11 @@
                 i.fas.fa-trash
               span Delete
 
-    div.modal(v-if="isDeleteModalOpen",
-              v-bind:class="{ 'is-active': isDeleteModalOpen }"
-              v-bind:data="deleteModalData")
+    div.modal(
+      v-if="isDeleteModalOpen"
+      v-bind:class="{ 'is-active': isDeleteModalOpen }"
+      v-bind:data="deleteModalData"
+    )
       div.modal-background
       div.modal-card
         header.modal-card-head
@@ -81,7 +83,7 @@
           p Are you sure you want to delete the role for user <b>{{ deleteModalData.username }}</b>?
         footer.modal-card-foot.pt20.pb20.pr20.pl20.has-background-white-ter
           a.button.is-primary(v-on:click="removeRoleMapping(deleteModalData.id)")
-              span Delete
+            span Delete
           button.button(v-on:click="isDeleteModalOpen = !isDeleteModalOpen") Cancel
 </template>
 


### PR DESCRIPTION
Adds a confirmation modal before deleting labels and users as requested in [issue 314](https://github.com/chakki-works/doccano/issues/314)

<img width="775" alt="Screen Shot 2019-11-04 at 4 39 30 PM" src="https://user-images.githubusercontent.com/8159064/68169617-b3f9b180-ff21-11e9-8852-9056ccecd138.png">


